### PR TITLE
Fix window scaling factor return value

### DIFF
--- a/winput/winput.py
+++ b/winput/winput.py
@@ -433,7 +433,10 @@ def get_window_scaling_factor(hwnd : int) -> float: # gets the DPI scaling facto
         return dpiX.value / 96.0
     if hasattr(ctypes.windll.gdi32, "GetDeviceCaps"):
         hdc = user32.GetDC(hwnd)
-        out = ctypes.windll.gdi32.GetDeviceCaps(hdc, LOGPIXELSX) / 96.0
+        try:
+            return ctypes.windll.gdi32.GetDeviceCaps(hdc, LOGPIXELSX) / 96.0
+        finally:
+            user32.ReleaseDC(hwnd, hdc)
 
     return 1.0
         


### PR DESCRIPTION
## Summary
- return actual DPI scaling from `get_window_scaling_factor`
- release device context after use

## Testing
- `python -m py_compile winput/winput.py`

------
https://chatgpt.com/codex/tasks/task_e_684ffccbe64c833397dcfe2a2914acf2